### PR TITLE
Update index.md

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -12,7 +12,7 @@ feedbackmail: wai@w3.org
 footer: >
   <p><strong>Date:</strong> Updated 29 June 2022. First published March 2019.</p>
   <p><strong>Editors:</strong> <a href="http://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and <a href="http://www.w3.org/People/roy/">Ruoxi Ran</a>.</p>
-  <p>Developed with input from the <a href="https://www.w3.org/WAI/APA/task-forces/personalization/">WAI-Adapt Task Force</a>.<p>
+  <p>Developed with input from the <a href="https://www.w3.org/WAI/APA/task-forces/adapt/">WAI-Adapt Task Force</a>.<p>
 ---
 
 {::nomarkdown}
@@ -66,14 +66,14 @@ WAI-Adapt enables users to use adaptive widgets and user preferences to customiz
 * **User agents** such as browser extensions and assistive technology can use the syntax to manipulate the content to meet the user’s need. User agents can also use user preferences for different interface options.
 
 ## The WAI-Adapt Documents
-* [Requirements for WAI-Adapt Specificationss](https://www.w3.org/TR/adapt-requirements/) (Working Draft Note) includes user stories, specific use cases, and requirements for Adapt.
+* [Requirements for WAI-Adapt Specifications](https://www.w3.org/TR/adapt-requirements/) (Working Draft Note) includes user stories, specific use cases, and requirements for enabling adaptable content.
 * [WAI-Adapt Explainer](https://www.w3.org/TR/adapt/) (Working Draft Note) is the core introductory document that explains general use cases, vocabulary, and anticipated uses.
 * [WAI-Adapt: Content Module](https://www.w3.org/TR/adapt-content/) (Working Draft specification) is the technical specification that provides terms authors can use to enhance web content with information about controls, symbols, and user interface elements.
 * [WAI-Adapt: Help and Support Module](https://www.w3.org/TR/adapt-help/) (Working Draft) lists examples of the adapted help and support properties.
 * [WAI-Adapt: Tools Module](https://www.w3.org/TR/adapt-tools/) (Working Draft) lists examples of the adapt tools properties.
 
 ## Who Develops WAI-Adapt
-WAI-Adapt documents are developed by the [WAI-Adapt Task Force](https://www.w3.org/WAI/APA/task-forces/personalization/) of the Accessible Platform Architectures Working Group ([APA WG](https://www.w3.org/WAI/APA/)), which is part of the World Wide Web Consortium ([W3C](http://www.w3.org/)) Web Accessibility Initiative ([WAI](http://www.w3.org/WAI/)). For more information about the task force, see the [WAI-Adapt Task Force page](https://www.w3.org/WAI/APA/task-forces/personalization/).
+WAI-Adapt documents are developed by the [WAI-Adapt Task Force](https://www.w3.org/WAI/APA/task-forces/personalization/) of the Accessible Platform Architectures Working Group ([APA WG](https://www.w3.org/WAI/APA/)), which is part of the World Wide Web Consortium ([W3C](http://www.w3.org/)) Web Accessibility Initiative ([WAI](http://www.w3.org/WAI/)). For more information about the task force, see the [WAI-Adapt Task Force page](https://www.w3.org/WAI/APA/task-forces/adapt/).
 
 Formal periods for public review are described in [How WAI Develops Accessibility Guidelines through the W3C Process: Milestones and Opportunities to Contribute](http://www.w3.org/WAI/intro/w3c-process). To submit comments on specific WAI-Adapt documents, see the “Status of this Document” section of the resource. To get notices of opportunities for review and comment on WAI documents, see [Get WAI News](https://www.w3.org/WAI/news/subscribe/).
 


### PR DESCRIPTION
Fixed a misspelling, clarified description of the "Requirements for WAI-Adapt Specifications" by replacing "Adapt" with "enabling adaptable content", and changed link to the new address of the task force page to avoid the redirect.

@shawna-slh One thing I didn't change: the repository info, though I think it moved to https://github.com/w3c/adapt.  The original personalization repository still exists in github.